### PR TITLE
fix memory leak in ll_angle() with grad_nfa

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .idea/*
 *.pyc
 cmake-build-*
+pytlsd.egg-info/*
+*.so


### PR DESCRIPTION
I found that memory leak is caused by calling ll_angle() with *mem_p twice.  In ll_angle(), it will allocate memory to *mem_p, but not released in the function. So if calling this function with *mem_p twice, the memory allocated first will be lost, leading to memory leak.